### PR TITLE
[OKTA-7] Improve Okta group handling

### DIFF
--- a/connector/src/main/java/net/tirasa/connid/bundles/okta/schema/OktaSchemaBuilder.java
+++ b/connector/src/main/java/net/tirasa/connid/bundles/okta/schema/OktaSchemaBuilder.java
@@ -110,6 +110,12 @@ class OktaSchemaBuilder {
         AttributeInfoBuilder attributeInfo = new AttributeInfoBuilder();
         attributeInfo.setRequired(true);
         attributeInfos.add(AttributeInfoBuilder.build(OktaAttribute.ID, String.class));
+
+        attributeInfos.add(AttributeInfoBuilder.define(OktaAttribute.OKTA_GROUPS, String.class)
+                .setMultiValued(true)
+                .setReturnedByDefault(false)
+                .build());
+
         return attributeInfos;
     }
 

--- a/connector/src/main/java/net/tirasa/connid/bundles/okta/utils/OktaAttribute.java
+++ b/connector/src/main/java/net/tirasa/connid/bundles/okta/utils/OktaAttribute.java
@@ -132,7 +132,10 @@ public final class OktaAttribute {
             } else if (OKTA_GROUPS.equals(attributeToGetName)) {
                 try {
                     List<String> assignedGroups =
-                            user.listGroups().stream().map(item -> item.getId()).collect(Collectors.toList());
+                            user.listGroups().stream()
+                                    .filter(item -> !isDefaultEveryoneGroup(item))
+                                    .map(item -> item.getId())
+                                    .collect(Collectors.toList());
                     attributes.add(buildAttribute(assignedGroups, attributeToGetName, Set.class).build());
                 } catch (Exception ex) {
                     LOG.error(ex, "Could not list groups for User {0}", user.getId());
@@ -246,5 +249,9 @@ public final class OktaAttribute {
 
     public static String buildProfileAttrName(final String name) {
         return "profile." + name;
+    }
+
+    public static boolean isDefaultEveryoneGroup(Group group) {
+        return group.getType().name().equals("BUILT_IN") && group.getProfile().getName().equals("Everyone");
     }
 }

--- a/fit/src/test/java/net/tirasa/connid/bundles/okta/OktaConnectorTests.java
+++ b/fit/src/test/java/net/tirasa/connid/bundles/okta/OktaConnectorTests.java
@@ -254,20 +254,9 @@ public class OktaConnectorTests extends AbstractConnectorTests {
             assertNotNull(groupUpdate.getId());
             GROUPS.add(groupUpdate.getId());
 
-            //Add default group everyone
-            GroupList groups = conn.getClient().listGroups("Everyone", null, null);
-            Group group;
-            if (groups.iterator().hasNext()) {
-                group = groups.single();
-            } else {
-                group = GroupBuilder.instance()
-                        .setName("Everyone")
-                        .setDescription("Everyone").buildAndCreate(conn.getClient());
-            }
-
             // UPDATE USER
             userAttrs.remove(password);
-            userAttrs.add(AttributeBuilder.build(OktaAttribute.OKTA_GROUPS, groupUpdate.getId(), group.getId()));
+            userAttrs.add(AttributeBuilder.build(OktaAttribute.OKTA_GROUPS, groupUpdate.getId()));
 
             Uid updated = connector.update(ObjectClass.ACCOUNT, created, userAttrs, operationOption);
             assertNotNull(updated);
@@ -275,8 +264,9 @@ public class OktaConnectorTests extends AbstractConnectorTests {
             assignedGroups = getUserGroups(conn.getClient(), updated.getUidValue());
             assertTrue(assignedGroups.contains(groupUpdate.getId()));
         } catch (Exception e) {
-            fail();
             LOG.error(e, "While running test");
+            throw e;
+            //fail();
         }
     }
 
@@ -320,21 +310,10 @@ public class OktaConnectorTests extends AbstractConnectorTests {
             assertEquals(handler.getObjects().get(0).getUid().getUidValue(), created.getUidValue());
             LOG.info("Created User with id {0} on Okta", handler.getObjects().get(0).getUid());
 
-            //Add default group everyone
-            GroupList groups = conn.getClient().listGroups("Everyone", null, null);
-            Group group;
-            if (groups.iterator().hasNext()) {
-                group = groups.single();
-            } else {
-                group = GroupBuilder.instance()
-                        .setName("Everyone")
-                        .setDescription("Everyone").buildAndCreate(conn.getClient());
-            }
-
             // UPDATE USER
             userAttrs.remove(password);
             userAttrs.add(
-                    AttributeBuilder.build(OktaAttribute.OKTA_GROUPS, group.getId()));
+                    AttributeBuilder.build(OktaAttribute.OKTA_GROUPS));
 
             Uid updated = connector.update(ObjectClass.ACCOUNT, created, userAttrs, operationOption);
             assertNotNull(updated);

--- a/server-mock/src/main/java/net/tirasa/connid/bundles/okta/servermock/impl/AbstractServiceImpl.java
+++ b/server-mock/src/main/java/net/tirasa/connid/bundles/okta/servermock/impl/AbstractServiceImpl.java
@@ -18,6 +18,7 @@ package net.tirasa.connid.bundles.okta.servermock.impl;
 import io.swagger.model.Application;
 import io.swagger.model.Group;
 import io.swagger.model.GroupProfile;
+import io.swagger.model.GroupType;
 import io.swagger.model.LogEvent;
 import io.swagger.model.LogTarget;
 import io.swagger.model.User;
@@ -54,7 +55,7 @@ public abstract class AbstractServiceImpl {
 
     protected static final List<Group> GROUP_REPOSITORY =
             Collections.synchronizedList(new ArrayList<Group>(Arrays.asList(
-                    new Group().id(EVERYONE_ID).profile(new GroupProfile().name(EVERYONE).description(
+                    new Group().id(EVERYONE_ID).type(GroupType.BUILT_IN).profile(new GroupProfile().name(EVERYONE).description(
                             EVERYONE)))));
 
     protected static final List<Pair<String, String>> GROUP_USER_REPOSITORY =

--- a/server-mock/src/main/java/net/tirasa/connid/bundles/okta/servermock/impl/GroupApiServiceImpl.java
+++ b/server-mock/src/main/java/net/tirasa/connid/bundles/okta/servermock/impl/GroupApiServiceImpl.java
@@ -92,6 +92,10 @@ public class GroupApiServiceImpl extends AbstractServiceImpl implements GroupApi
      */
     @Override
     public Response addUserToGroup(String groupId, String userId) {
+        if (EVERYONE_ID.equals(groupId)) {
+            // Okta Groups API returns 501 error when adding a user to default Everyone group
+            return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+        }
         if (GROUP_REPOSITORY.stream().anyMatch(group -> StringUtils.equals(groupId, group.getId()))
                 && USER_REPOSITORY.stream().anyMatch(user -> StringUtils.equals(userId, user.getId()))) {
             GROUP_USER_REPOSITORY.add(Pair.of(groupId, userId));


### PR DESCRIPTION
- Add `oktaGroups` attribute to Okta user schema.
- Support for adding/updating Okta group.
- Exclude Okta's built-in `Everyone` group.
  Okta User is automatically assigned to the `Everyone` group upon creation. The group also cannot be unassigned. Therefore, it should be excluded from processing in this connector.
- Improve fetching Okta group by UID.